### PR TITLE
[WIP] Mdtool hang

### DIFF
--- a/builder.rb
+++ b/builder.rb
@@ -62,7 +62,7 @@ class Builder
   def run_mdtool_in_diagnostic_mode(mdtool_build_command)
     pipe = nil
 
-    timer = Timer.new(900) { # 15 minutes timeout
+    timer = Timer.new(300) { # 5 minutes timeout
       hijack_process(pipe.pid)
     }
 

--- a/builder.rb
+++ b/builder.rb
@@ -34,7 +34,7 @@ class Builder
       puts "\e[34m#{build_command}\e[0m"
       puts
 
-      if ([MDTOOL_PATH, 'build'] & build_command).present?
+      if ([MDTOOL_PATH, 'build', 'archive'] & build_command).any?
         run_mdtool_in_diagnostic_mode(build_command)
       else
         raise 'Build failed' unless system(build_command.join(' '))
@@ -67,12 +67,10 @@ class Builder
     }
 
     puts
-    puts "Run build in diagnostic mode: \e[34m#{build_command}\e[0m"
+    puts "Run build in diagnostic mode: \e[34m#{mdtool_build_command}\e[0m"
     puts
 
-    pipe = IO.popen(mdtool_build_command.join(' '))
-
-    pipe.each do |line|
+    pipe = IO.popen(mdtool_build_command.join(' ')).each do |line|
       puts line
       timer.stop if timer.running?
       timer.start if line.include? "Loading projects"

--- a/builder.rb
+++ b/builder.rb
@@ -1,5 +1,6 @@
 require_relative './analyzer'
 require_relative './common_constants'
+require_relative './timer'
 
 class Builder
   def initialize(path, configuration, platform, project_type_filter=nil)
@@ -33,10 +34,53 @@ class Builder
       puts "\e[34m#{build_command}\e[0m"
       puts
 
-      raise 'Build failed' unless system(build_command.join(' '))
+      if ([MDTOOL_PATH, 'build'] & build_command).present?
+        run_mdtool_in_diagnostic_mode(build_command)
+      else
+        raise 'Build failed' unless system(build_command.join(' '))
+      end
     end
 
     @generated_files = @analyzer.collect_generated_files(@configuration, @platform, @project_type_filter)
+  end
+
+  # README:
+  # This method will run `mdtool build` in diagnostic mode.
+  # If mdtool will hang trying to load projects its process will be killed
+  # and stack trace for each thread of mdtool will be printed to stdout.
+  # Issue on Bugzilla: https://bugzilla.xamarin.com/show_bug.cgi?id=42378
+
+  # List of things to be removed as as soon as #42378 will be resolved:
+  # 1) run_mdtool_in_diagnostic_mode method
+  # 2) hijack_process method
+  # 3) MDTOOL_PATH constant in Builder class
+  # 4) Entire Timer class
+  # 5) if/else logic in Builder.build
+
+  MDTOOL_PATH = "\"/Applications/Xamarin Studio.app/Contents/MacOS/mdtool\""
+
+  def run_mdtool_in_diagnostic_mode(mdtool_build_command)
+    pipe = nil
+
+    timer = Timer.new(900) { # 15 minutes timeout
+      hijack_process(pipe.pid)
+    }
+
+    puts
+    puts "Run build in diagnostic mode: \e[34m#{build_command}\e[0m"
+    puts
+
+    pipe = IO.popen(mdtool_build_command.join(' '))
+
+    pipe.each do |line|
+      puts line
+      timer.stop if timer.running?
+      timer.start if line.include? "Loading projects"
+    end
+  end
+
+  def hijack_process(process_id)
+    puts `kill -QUIT #{process_id}`
   end
 
   def build_solution

--- a/timer.rb
+++ b/timer.rb
@@ -1,0 +1,125 @@
+require 'timeout'
+
+class Timer
+
+  def initialize(time_limit=nil, &block)
+    # standard timer
+    @start_time = nil
+    @end_time = nil
+    @total_time = 0
+    @runnning = nil
+    # for using time limit
+    @time_limit = time_limit
+    @on_timeout = block
+    @current_thread = nil
+    @timer_thread = nil
+  end
+
+  attr_accessor :time_limit
+
+  def start_time
+    @start_time
+  end
+
+  def end_time
+    @end_time
+  end
+
+  def on_timeout( &block )
+    if block then
+      @on_timeout = block
+      true
+    else
+      false
+    end
+  end
+
+  # Start the timer.
+  def start
+    @running = true
+    @start_time = Time.now
+
+    limit if @time_limit
+
+    self
+  end
+
+  # Establish a time limit on execution.
+  def limit( time_limit=nil )
+    if @time_limit || time_limit
+      @current_thread = Thread.current
+      @timer_thread = Thread.fork {
+        sleep @time_limit
+        if @on_timeout then
+          @on_timeout.call @time_limit
+        else
+          @current_thread.raise Timeout::Error, "#{@time_limit} seconds past"
+        end
+      }
+    end
+  end
+
+  # Kill time limit thread, if any.
+  def defuse
+    if @timer_thread
+      #Thread.kill @timer_thread
+      @timer_thread.kill
+      @timer_thread = nil
+    end
+  end
+
+  # Stops timer and returns total time.
+  # If timer was not running returns false.
+  def stop
+    if @running
+      defuse
+      # record running time
+      @end_time = Time.now
+      @running = false
+      @total_time += (@end_time - @start_time)
+    else
+      nil
+    end
+  end
+
+  # Stops and resets the timer. If the timer was running
+  # returns the total time. If not returns 0.
+  def reset
+    if running?
+      r = stop
+    else
+      r = 0
+    end
+    @total_time = 0
+    return r
+  end
+
+  def reset_limit
+    defuse
+    limit
+  end
+
+  # Queries whether the timer is still running.
+  def running?
+    return @running
+  end
+
+  # Queries whether the timer is still not running.
+  def stopped?
+    return !@running
+  end
+
+  # Queries total recorded time of timer.
+  def total_time
+    if running? then
+      return @total_time + (Time.now - @start_time)
+    else
+      return @total_time
+    end
+  end
+
+  def self.time
+    yield( timer = Timer.new.start )
+    return timer.total_time
+  end
+end


### PR DESCRIPTION
If mdtool will hang trying to load projects its process will be killed and stack trace for each thread of mdtool will be printed to STDOUT. It should help us to diagnose and fix the problem.

Issue on Bugzilla: https://bugzilla.xamarin.com/show_bug.cgi?id=42378

List of things to be removed as as soon as #42378 will be resolved:
- run_mdtool_in_diagnostic_mode method
- hijack_process method
- MDTOOL_PATH constant in Builder class
- Entire Timer class
- if/else logic in Builder.build
